### PR TITLE
Eliminacion API_INGESTA_KEY

### DIFF
--- a/app/Config/routes.php
+++ b/app/Config/routes.php
@@ -37,7 +37,6 @@ return [
     'POST /micuenta' => [UsuarioController::class, 'miCuenta'],
 
     // API para app móvil
-    'GET /api/ping' => [AuthApiController::class, 'ping'],
     'POST /api/login' => [AuthApiController::class, 'login'],
     'POST /api/logout' => [AuthApiController::class, 'logout'],
     'GET /api/me' => [AuthApiController::class, 'me'],

--- a/app/Config/routes.php
+++ b/app/Config/routes.php
@@ -37,6 +37,7 @@ return [
     'POST /micuenta' => [UsuarioController::class, 'miCuenta'],
 
     // API para app móvil
+    'GET /api/ping' => [AuthApiController::class, 'ping'],
     'POST /api/login' => [AuthApiController::class, 'login'],
     'POST /api/logout' => [AuthApiController::class, 'logout'],
     'GET /api/me' => [AuthApiController::class, 'me'],

--- a/app/Controllers/AuthApiController.php
+++ b/app/Controllers/AuthApiController.php
@@ -1,11 +1,6 @@
 <?php
 class AuthApiController
 {
-    public function ping(): void
-    {
-        jsonResponse(['ok' => true, 'time' => time()]);
-    }
-
     public function login(): void
     {
         $body = json_decode(file_get_contents('php://input'), true) ?? $_POST;

--- a/app/Controllers/AuthApiController.php
+++ b/app/Controllers/AuthApiController.php
@@ -1,6 +1,11 @@
 <?php
 class AuthApiController
 {
+    public function ping(): void
+    {
+        jsonResponse(['ok' => true, 'time' => time()]);
+    }
+
     public function login(): void
     {
         $body = json_decode(file_get_contents('php://input'), true) ?? $_POST;
@@ -17,7 +22,8 @@ class AuthApiController
         }
         $_SESSION['rut'] = $auth['rut'];
         $_SESSION['idPerfil'] = (string)$auth['idPerfil'];
-        jsonResponse(['rut' => $auth['rut'], 'idPerfil' => (int)$auth['idPerfil']]);
+        // Retornar también el ID de sesión para clientes que no persistan cookies automáticamente
+        jsonResponse(['rut' => $auth['rut'], 'idPerfil' => (int)$auth['idPerfil'], 'sid' => session_id()]);
     }
 
     public function logout(): void

--- a/app/Controllers/MonitorController.php
+++ b/app/Controllers/MonitorController.php
@@ -41,8 +41,15 @@ class MonitorController
 
     public function ingesta(): void
     {
-        // Requerir API Key para ingestas (microcontrolador y app móvil)
-        ApiKeyMiddleware::requireValid();
+        // Requerir sesión y permiso de usuario para ingresar lecturas
+        ApiSessionMiddleware::requireAuth();
+        $idPerfil = isset($_SESSION['idPerfil']) ? (int)$_SESSION['idPerfil'] : null;
+        // Política: solo Trabajador (idPerfil = 2) puede ingresar lecturas manuales
+        if ($idPerfil !== 2) {
+            http_response_code(403);
+            echo 'No autorizado para ingresar lecturas';
+            exit();
+        }
         $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
         $payload = [];
         if (stripos($contentType, 'application/json') !== false) {

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -26,9 +26,6 @@ return [
         'pass' => getenv('DB_PASS'),
         'charset' => 'utf8mb4',
     ],
-    'api' => [
-        'ingesta_key' => getenv('API_INGESTA_KEY') ?: 'CAMBIAR_ESTA_CLAVE',
-    ],
 ];
 PHP
 

--- a/public/index.php
+++ b/public/index.php
@@ -89,7 +89,7 @@ function sendCorsHeaders(): void
     header('Access-Control-Allow-Origin: ' . $origin);
     header('Vary: Origin');
     header('Access-Control-Allow-Credentials: true');
-    header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, X-Session-Id');
+    header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, X-Session-Id, X-Api-Key');
     header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
 }
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,4 +1,10 @@
 <?php
+// Permitir autenticación por header 'X-Session-Id' (alternativa a cookies para apps nativas)
+$sidHeader = $_SERVER['HTTP_X_SESSION_ID'] ?? null;
+if ($sidHeader && is_string($sidHeader)) {
+    @session_id($sidHeader);
+}
+
 // Configurar cookie de sesión apta para apps móviles (HTTPS, SameSite=None)
 session_set_cookie_params([
     'lifetime' => 0,
@@ -83,7 +89,7 @@ function sendCorsHeaders(): void
     header('Access-Control-Allow-Origin: ' . $origin);
     header('Vary: Origin');
     header('Access-Control-Allow-Credentials: true');
-    header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With');
+    header('Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, X-Session-Id');
     header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
 }
 


### PR DESCRIPTION
Se repara ruta /api/ingesta que estaba mal configurada para que reciba sesion de usuario y no una API_INGESTA_KEY porque eso no es lo que se solicito por el cliente.